### PR TITLE
Update Pie.php

### DIFF
--- a/src/Chart/Pie.php
+++ b/src/Chart/Pie.php
@@ -1156,7 +1156,7 @@ class Pie
             }
         }
 
-        $this->Shadow = $RestoreShadow;
+        $this->pChartObject->Shadow = $RestoreShadow;
     }
 
     /**


### PR DESCRIPTION
Fix PHP 8.2 deprecation: Creation of dynamic property `CpChart\\Chart\\Pie::$Shadow` is deprecated. This happens because the property Shadow belongs to `$this->pChartObject` and not to `$this`.